### PR TITLE
Adds a simple SSL wrapper to the callback server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 secrets.py
 *.pyc
+*.pem

--- a/secrets.py.template
+++ b/secrets.py.template
@@ -11,3 +11,6 @@ GROUPME_PORT      = 8000
 # These two are very important, they stop the bot from echoing itself
 ZULIP_BOT_NAME    = "Groupme_bot"
 GROUPME_BOT_NAME  = "ABTech Bot"
+
+# Path to a private key and public cert to ssl
+SSL_CERT_PATH     = "localhost.pem"

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import threading
 import json
 import requests
 import secrets
+import ssl
 
 # !!! Please fill in all constants in secrets.py before operating !!!
 
@@ -54,6 +55,7 @@ def run_groupme_listener():
     server_address = ('', secrets.GROUPME_PORT)
     httpd = HTTPServer(server_address, S)
     print 'Starting httpd...'
+    httpd.socket = ssl.wrap_socket (httpd.socket, certfile=secrets.SSL_CERT_PATH, server_side=True) 
     httpd.serve_forever()
 
 # Wrapper for the zulip listener for threading


### PR DESCRIPTION
Current head has the groupme server send the API key in the clear, since that's the only thing being used for authentication it should probably be encrypted. Groupme's API is fine with self-signed certs so still vulnerable to MITM, etc.